### PR TITLE
使用app.listen也许更简洁

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,6 +51,6 @@ app.configure('production', function () {
 
 routes(app);
 
-http.createServer(app).listen(app.get('port'), function () {
+app.listen(app.get('port'), function () {
   console.log("Express server listening on port " + app.get('port'));
 });


### PR DESCRIPTION
http.createServer(app)与app.listen有同样的效果，参见[express源码](https://github.com/strongloop/express/blob/3e4158bcbda7017dbe7226fb76d974bd95c29ce9/lib/application.js#L540) 

所以，我想使用app.listen会看起来更简洁。谢谢
